### PR TITLE
[sai-ptf] set expected exception and fix errors in test

### DIFF
--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -22,11 +22,30 @@ This file contains class for brcm specified functions.
 
 from platform_helper.common_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
+CATCH_EXCEPTIONS=True
+# SAI_STATUS_NOT_IMPLEMENTED
+ACCEPTED_ERROR_CODE = [SAI_STATUS_NOT_IMPLEMENTED]
+#SAI_STATUS_ATTR_NOT_IMPLEMENTED
+ACCEPTED_ERROR_CODE += range(SAI_STATUS_ATTR_NOT_IMPLEMENTED_MAX, SAI_STATUS_ATTR_NOT_IMPLEMENTED_0)
+#SAI_STATUS_ATTR_NOT_IMPLEMENTED
+ACCEPTED_ERROR_CODE += range(SAI_STATUS_UNKNOWN_ATTRIBUTE_MAX, SAI_STATUS_UNKNOWN_ATTRIBUTE_0)
+#SAI_STATUS_ATTR_NOT_SUPPORTED
+ACCEPTED_ERROR_CODE += range(SAI_STATUS_ATTR_NOT_SUPPORTED_MAX, SAI_STATUS_ATTR_NOT_SUPPORTED_0)
+
+
 class BrcmSaiHelper(CommonSaiHelper):
     """
     This class contains broadcom(brcm) specified functions for the platform setup and test context configuration.
     """
     platform = 'brcm'
+
+    def set_accepted_exception(self):
+        """
+        Set accepted exceptions.
+        """
+        adapter.CATCH_EXCEPTIONS=CATCH_EXCEPTIONS
+        adapter.EXPECTED_ERROR_CODE += ACCEPTED_ERROR_CODE
+
 
     def remove_switch(self):
         '''
@@ -263,5 +282,9 @@ class BrcmSaiHelper(CommonSaiHelper):
             self.portX objects for all active ports
         '''
         #In case the bridge port will be initalized by default, clear them
+        # There will be errors if the bridge doesn't exist
+        pre_execption_stat = adapter.CATCH_EXCEPTIONS
+        adapter.CATCH_EXCEPTIONS = True
         default_1q_bridge_port_list = self.load_default_1q_bridge_ports()
         self.remove_1q_bridge_port(default_1q_bridge_port_list)
+        adapter.CATCH_EXCEPTIONS = pre_execption_stat

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -313,9 +313,18 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.client, init_switch=True, warm_recover=True)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
+
+    def set_accepted_exception(self):
+        """
+        Set accepted exceptions.
+        """
+        adapter.CATCH_EXCEPTIONS=True
+
+
     def setUp(self):
         super(SaiHelperBase, self).setUp()
         self.set_logger_name()
+        self.set_accepted_exception()
         self.getSwitchPorts()
         # initialize switch
         self.start_switch()

--- a/ptf/sairoute.py
+++ b/ptf/sairoute.py
@@ -1084,10 +1084,12 @@ class DirBcastGleanAndForwardTest(L3DirBcastRouteTestHelper):
                 sai_thrift_remove_next_hop(self.client, nhop1)
             if nhop2:
                 sai_thrift_remove_next_hop(self.client, nhop2)
-
-            sai_thrift_remove_neighbor_entry(self.client, nbr_entry1)
-            sai_thrift_remove_neighbor_entry(self.client, nbr_entry2)
-            sai_thrift_remove_neighbor_entry(self.client, nbr_entry0)
+            if 'nbr_entry1' in locals():
+                sai_thrift_remove_neighbor_entry(self.client, nbr_entry1)
+            if 'nbr_entry2' in locals():
+                sai_thrift_remove_neighbor_entry(self.client, nbr_entry2)
+            if 'nbr_entry0' in locals():
+                sai_thrift_remove_neighbor_entry(self.client, nbr_entry0)
 
     def tearDown(self):
         super(DirBcastGleanAndForwardTest, self).tearDown()


### PR DESCRIPTION
# Why
## Acceptable errors
In SAI-PTF test cases, in some platforms some interface/attribute might not implemented/support.
Then we need to skip the test for unsupported errors

## syntax error
Fix syntax error when cases running into bad state for some unexpected code path

# How
Add error code and check the API state after return. Handle the errors base on defined acceptable errors.
Fix syntax error

# Test
Pipeline